### PR TITLE
Fix #15 Astro DB no longer exports type Sqlitedb

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"typescript": "^5.5.3"
 	},
 	"peerDependencies": {
-		"@astrojs/db": "^0.11",
+		"@astrojs/db": "^0.12.0",
 		"lucia": "3.x"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
 		"url": "https://github.com/pilcrowOnPaper/lucia-adapter-astrodb"
 	},
 	"devDependencies": {
-		"@astrojs/db": "^0.11.7",
+		"@astrojs/db": "^0.12.0",
 		"@lucia-auth/adapter-test": "^5.0.1",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"@typescript-eslint/parser": "^6.21.0",
 		"auri": "1.0.2",
 		"eslint": "^8.57.0",
 		"lucia": "^3.2.0",
-		"prettier": "^3.3.2",
+		"prettier": "^3.3.3",
 		"typescript": "^5.5.3"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,18 +26,18 @@
 		"url": "https://github.com/pilcrowOnPaper/lucia-adapter-astrodb"
 	},
 	"devDependencies": {
-		"@astrojs/db": "0.8.6",
+		"@astrojs/db": "^0.11.7",
 		"@lucia-auth/adapter-test": "^5.0.1",
-		"@typescript-eslint/eslint-plugin": "^6.7.5",
-		"@typescript-eslint/parser": "^6.7.5",
+		"@typescript-eslint/eslint-plugin": "^6.21.0",
+		"@typescript-eslint/parser": "^6.21.0",
 		"auri": "1.0.2",
-		"eslint": "^8.51.0",
-		"lucia": "^3.1.1",
-		"prettier": "^3.0.3",
-		"typescript": "^5.2.2"
+		"eslint": "^8.57.0",
+		"lucia": "^3.2.0",
+		"prettier": "^3.3.2",
+		"typescript": "^5.5.3"
 	},
 	"peerDependencies": {
-		"@astrojs/db": "0.8 - 0.11",
+		"@astrojs/db": "^0.11",
 		"lucia": "3.x"
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
 /// <reference types="@astrojs/db" />
 import { eq, lte } from "astro:db";
 
-import type { SqliteDB, Table } from "@astrojs/db/runtime";
+import type { Database, Table } from "@astrojs/db/runtime";
 import type { Adapter, DatabaseSession, DatabaseUser, UserId } from "lucia";
 
 export class AstroDBAdapter implements Adapter {
-	private db: SqliteDB;
+	private db: Database;
 
 	private sessionTable: SessionTable;
 	private userTable: UserTable;
 
-	constructor(db: SqliteDB, sessionTable: SessionTable, userTable: UserTable) {
+	constructor(db: Database, sessionTable: SessionTable, userTable: UserTable) {
 		this.db = db;
 		this.sessionTable = sessionTable;
 		this.userTable = userTable;


### PR DESCRIPTION
There were no tests, not sure if this will work or not. It now only supports @astrojs/db >= 0.11.